### PR TITLE
ci: add Brew formula update action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  brew:
+    runs-on: macos-latest
+
+    name: Brew Formula
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Update Homebrew Formula
+        uses: dawidd6/action-homebrew-bump-formula@v3
+        with:
+          # Token (GitHub PAT with 'public_repo' scope)
+          token: ${{ secrets.BREW_ACCESS_TOKEN }}
+
+          # Formula name
+          formula: tldr

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,8 +18,5 @@ jobs:
       - name: Update Homebrew Formula
         uses: dawidd6/action-homebrew-bump-formula@v3
         with:
-          # Token (GitHub PAT with 'public_repo' scope)
           token: ${{ secrets.BREW_ACCESS_TOKEN }}
-
-          # Formula name
           formula: tldr


### PR DESCRIPTION
## What does it do?
This automatically creates a PR to the [`homebrew/core` tap](https://github.com/Homebrew/homebrew-core) with the bumped `tldr` formula version.


## Why the change?
This allows us to automatically be able to release new versions to Brew without having to do it manually.


## How can this be tested?
Not really sure...


## Where to start code review?
https://github.com/dawidd6/action-homebrew-bump-formula#standard-mode

~~Note, this will require a new PAT token (with `public_repo` scope), which I think we should generate with the @tldr-bot account. This then needs to be added as a GitHub secret with the name `BREW_ACCESS_TOKEN` for the action to work.~~
The new token has now been set up. 👍🏻