### PR TITLE
Add yum support to dependency script

### DIFF
--- a/deps.sh
+++ b/deps.sh
@@ -30,9 +30,9 @@ elif [ "$UNAME" = "Linux" ]; then
         yum install -y libcurl-devel libzip-devel pkgconfig || exit 1
     else
         echo "Unknown Linux distribution"
+        exit 1
     fi
 else
     echo "Unknown platform"
     exit 1
 fi
-

--- a/deps.sh
+++ b/deps.sh
@@ -12,6 +12,7 @@ if [ "$UNAME" = "Darwin" ]; then
 elif [ "$UNAME" = "Linux" ]; then
     HAS_APT=$(command -v apt-get > /dev/null >&1 && echo 1 || echo 0)
     HAS_PACMAN=$(command -v pacman > /dev/null >&1 && echo 1 || echo 0)
+    HAS_YUM=$(command -v yum > /dev/null >&1 && echo 1 || echo 0)
 
     if [ "$(id -u)" != "0" ]; then
         echo "Please run this script as root"
@@ -24,6 +25,11 @@ elif [ "$UNAME" = "Linux" ]; then
     elif [ "$HAS_PACMAN" -eq 1 ]; then
         pacman -Syy
         pacman -S libzip libcurl-gnutls pkg-config || exit 1
+    elif [ "$HAS_YUM" -eq 1 ]; then
+        yum makecache
+        yum install -y libcurl-devel libzip-devel pkgconfig || exit 1
+    else
+        echo "Unknown Linux distribution"
     fi
 else
     echo "Unknown platform"


### PR DESCRIPTION
## What does it do?
This change checks for yum, and installs dependencies needed for the project, in the same manner as is done for apt and pacman. It also prints "Unknown Linux distribution" if none of apt, pacman, or yum are not found.

## Why the change?
To easily add dependencies that might not be installed in a standard environment, in order to build the project.

## How can this be tested?
Was tested on new VMs of CentOS 7.9 and CentOS (8) Stream with only desktop environments and basic development tools (gcc, git, etc) installed (`sudo yum update; sudo yum groupinstall "Development Tools"`). Clone repo in VM and run `sudo ./deps.sh; make; sudo make install`

You can also grab the attached Dockerfile (much quicker than setting up a VM) and run:
docker build - < Dockerfile_tldr_yum.txt

[Dockerfile_tldr_yum.txt](https://github.com/tldr-pages/tldr-c-client/files/6209295/Dockerfile_tldr_yum.txt)

Can also be tested in any environment with yum, such as a RHEL or CentOS host OS.

## Where to start code review?
Look in deps.sh.

## Relevant tickets?
<Please link any relevant tickets>

## Questions?
<Ask us anything!>