### PR TITLE
replace master with main

### DIFF
--- a/autocomplete/complete.bash
+++ b/autocomplete/complete.bash
@@ -6,7 +6,7 @@
 
 _tldr_get_files() {
 	local ret
-	local files="$(find $HOME/.tldrc/tldr-master/pages/$1 -name '*.md' -exec basename {} .md \;)"
+	local files="$(find $HOME/.tldrc/tldr-main/pages/$1 -name '*.md' -exec basename {} .md \;)"
 
 	IFS=$'\n\t'
 	for f in $files; do
@@ -23,7 +23,7 @@ _tldr_complete() {
     elif [ "$word" = "--" ]; then
         cmpl=$(echo $'--version\n--help\n--update\n--clear-cache\n--platform\n--render' | sort)
     else
-        if [ -d "$HOME/.tldrc/tldr-master/pages" ]; then
+        if [ -d "$HOME/.tldrc/tldr-main/pages" ]; then
             local platform="$(uname)"
             cmpl="$(_tldr_get_files common | sort | uniq)"
             if [ "$platform" = "Darwin" ]; then

--- a/autocomplete/complete.bash
+++ b/autocomplete/complete.bash
@@ -6,7 +6,7 @@
 
 _tldr_get_files() {
 	local ret
-	local files="$(find $HOME/.tldrc/tldr-main/pages/$1 -name '*.md' -exec basename {} .md \;)"
+	local files="$(find $HOME/.tldrc/tldr/pages/$1 -name '*.md' -exec basename {} .md \;)"
 
 	IFS=$'\n\t'
 	for f in $files; do
@@ -23,7 +23,7 @@ _tldr_complete() {
     elif [ "$word" = "--" ]; then
         cmpl=$(echo $'--version\n--help\n--update\n--clear-cache\n--platform\n--render' | sort)
     else
-        if [ -d "$HOME/.tldrc/tldr-main/pages" ]; then
+        if [ -d "$HOME/.tldrc/tldr/pages" ]; then
             local platform="$(uname)"
             cmpl="$(_tldr_get_files common | sort | uniq)"
             if [ "$platform" = "Darwin" ]; then

--- a/autocomplete/complete.fish
+++ b/autocomplete/complete.fish
@@ -7,13 +7,13 @@ complete -c tldr -rf -f -s p -l platform -a "linux osx sunos common" -d "select 
 complete -c tldr -r -s r -l render -a PATH -d "render a local page for testing purpose"
 
 function __tldr_get_files
-    set -l files (basename -s .md (find $HOME/.tldrc/tldr-master/pages/$argv[1] -name '*.md'))
+    set -l files (basename -s .md (find $HOME/.tldrc/tldr-main/pages/$argv[1] -name '*.md'))
     for f in $files
         echo $f
     end
 end
 
-if test -d "$HOME/.tldrc/tldr-master/pages"
+if test -d "$HOME/.tldrc/tldr-main/pages"
     set -l cmpl (__tldr_get_files common)
 
     switch (uname)

--- a/autocomplete/complete.fish
+++ b/autocomplete/complete.fish
@@ -7,13 +7,13 @@ complete -c tldr -rf -f -s p -l platform -a "linux osx sunos common" -d "select 
 complete -c tldr -r -s r -l render -a PATH -d "render a local page for testing purpose"
 
 function __tldr_get_files
-    set -l files (basename -s .md (find $HOME/.tldrc/tldr-main/pages/$argv[1] -name '*.md'))
+    set -l files (basename -s .md (find $HOME/.tldrc/tldr/pages/$argv[1] -name '*.md'))
     for f in $files
         echo $f
     end
 end
 
-if test -d "$HOME/.tldrc/tldr-main/pages"
+if test -d "$HOME/.tldrc/tldr/pages"
     set -l cmpl (__tldr_get_files common)
 
     switch (uname)

--- a/autocomplete/complete.zsh
+++ b/autocomplete/complete.zsh
@@ -8,7 +8,7 @@
 
 _tldr_get_files() {
 	local ret
-	local files="$(find $HOME/.tldrc/tldr-master/pages/$1 -name '*.md' -exec basename {} .md \;)"
+	local files="$(find $HOME/.tldrc/tldr-main/pages/$1 -name '*.md' -exec basename {} .md \;)"
 
 	IFS=$'\n\t'
 	for f in $files; do
@@ -24,7 +24,7 @@ _tldr_complete() {
     elif [ "$word" = "--" ]; then
         cmpl=$(echo $'--version\n--help\n--update\n--clear-cache\n--platform\n--render' | sort)
     else
-        if [ -d "$HOME/.tldrc/tldr-master/pages" ]; then
+        if [ -d "$HOME/.tldrc/tldr-main/pages" ]; then
             local platform="$(uname)"
             cmpl="$(_tldr_get_files common | sort | uniq)"
             if [ "$platform" = "Darwin" ]; then

--- a/autocomplete/complete.zsh
+++ b/autocomplete/complete.zsh
@@ -8,7 +8,7 @@
 
 _tldr_get_files() {
 	local ret
-	local files="$(find $HOME/.tldrc/tldr-main/pages/$1 -name '*.md' -exec basename {} .md \;)"
+	local files="$(find $HOME/.tldrc/tldr/pages/$1 -name '*.md' -exec basename {} .md \;)"
 
 	IFS=$'\n\t'
 	for f in $files; do
@@ -24,7 +24,7 @@ _tldr_complete() {
     elif [ "$word" = "--" ]; then
         cmpl=$(echo $'--version\n--help\n--update\n--clear-cache\n--platform\n--render' | sort)
     else
-        if [ -d "$HOME/.tldrc/tldr-main/pages" ]; then
+        if [ -d "$HOME/.tldrc/tldr/pages" ]; then
             local platform="$(uname)"
             cmpl="$(_tldr_get_files common | sort | uniq)"
             if [ "$platform" = "Darwin" ]; then

--- a/src/tldr.h
+++ b/src/tldr.h
@@ -26,7 +26,7 @@
 #define TMP_FILE "/main.zip"
 #define TMP_FILE_LEN (sizeof(TMP_FILE) - 1)
 
-#define TLDR_DIR "/tldr-main"
+#define TLDR_DIR "/tldr"
 #define TLDR_DIR_LEN (sizeof(TLDR_DIR) - 1)
 
 #define TLDR_HOME "/.tldrc"
@@ -35,7 +35,7 @@
 #define TLDR_DATE "/.tldrc/date"
 #define TLDR_DATE_LEN (sizeof(TLDR_DATE) - 1)
 
-#define TLDR_EXT "/.tldrc/tldr-main/pages/"
+#define TLDR_EXT "/.tldrc/tldr/pages/"
 #define TLDR_EXT_LEN (sizeof(TLDR_EXT) - 1)
 
 #define ANSI_COLOR_RESET_FG                     "\x1b[39m"

--- a/src/tldr.h
+++ b/src/tldr.h
@@ -14,19 +14,19 @@
 #define STRBUFSIZ 512
 #define URLBUFSIZ 1024
 
-#define BASE_URL "https://raw.github.com/tldr-pages/tldr/master/pages"
+#define BASE_URL "https://raw.github.com/tldr-pages/tldr/main/pages"
 #define BASE_URL_LEN (sizeof(BASE_URL) - 1)
 
-#define ZIP_URL "https://github.com/tldr-pages/tldr/archive/master.zip"
+#define ZIP_URL "https://github.com/tldr-pages/tldr/archive/main.zip"
 #define ZIP_URL_LEN (sizeof(ZIP_URL_LEN) - 1)
 
 #define TMP_DIR "/tmp/tldrXXXXXX"
 #define TMP_DIR_LEN (sizeof(TMP_DIR) - 1)
 
-#define TMP_FILE "/master.zip"
+#define TMP_FILE "/main.zip"
 #define TMP_FILE_LEN (sizeof(TMP_FILE) - 1)
 
-#define TLDR_DIR "/tldr-master"
+#define TLDR_DIR "/tldr-main"
 #define TLDR_DIR_LEN (sizeof(TLDR_DIR) - 1)
 
 #define TLDR_HOME "/.tldrc"
@@ -35,7 +35,7 @@
 #define TLDR_DATE "/.tldrc/date"
 #define TLDR_DATE_LEN (sizeof(TLDR_DATE) - 1)
 
-#define TLDR_EXT "/.tldrc/tldr-master/pages/"
+#define TLDR_EXT "/.tldrc/tldr-main/pages/"
 #define TLDR_EXT_LEN (sizeof(TLDR_EXT) - 1)
 
 #define ANSI_COLOR_RESET_FG                     "\x1b[39m"


### PR DESCRIPTION
As far as I know, the master to main change shouldn't affect any client, however it broke the C client. I always get `Error: Could Not Rename: /tmp/tldr70oDX4/tldr-master to /home/user/.tldrc/tldr-master/` and `/tmp/tldr70oDX4/` just doesn't exist.

However after changing everything to main it works again.
