### PR TITLE
Fix updating error

### DIFF
--- a/src/local.c
+++ b/src/local.c
@@ -141,6 +141,7 @@ update_localdb(int verbose)
     char outpath[STRBUFSIZ];
     char outfile[STRBUFSIZ];
     char outhome[STRBUFSIZ];
+    char sysmv[STRBUFSIZ];
     char const *homedir;
     size_t outlen;
 
@@ -210,7 +211,17 @@ update_localdb(int verbose)
         }
     }
 
-    if (rename(tmp, outhome)) {
+    outlen = 0;
+    if (sstrncat(sysmv, &outlen, STRBUFSIZ, "mv ", 3))
+        return 1;
+    if (sstrncat(sysmv, &outlen, STRBUFSIZ, tmp, strlen(tmp)))
+        return 1;
+    if (sstrncat(sysmv, &outlen, STRBUFSIZ, " ", 1))
+        return 1;
+    if (sstrncat(sysmv, &outlen, STRBUFSIZ, outhome, strlen(outhome)))
+        return 1;
+
+    if (system(sysmv)) {
         fprintf(stderr, "Error: Could Not Rename: %s to %s\n", tmp, outhome);
         rm(outpath, 0);
         return 1;

--- a/src/tldr.h
+++ b/src/tldr.h
@@ -26,7 +26,7 @@
 #define TMP_FILE "/main.zip"
 #define TMP_FILE_LEN (sizeof(TMP_FILE) - 1)
 
-#define TLDR_DIR "/tldr"
+#define TLDR_DIR "/tldr-main" // this is the name of the directory inside `main.zip`
 #define TLDR_DIR_LEN (sizeof(TLDR_DIR) - 1)
 
 #define TLDR_HOME "/.tldrc"


### PR DESCRIPTION
Solves #64 
This issue is actually two issues.
The first one is in `local.h`. We download the file `main.zip`, which contains the directory `tldr-main`, but we expect `tldr`. This was may fault in #59 

But this is not the actual issue here. As already explained in #21, Linux mounts `/tmp` on a different filesystem than the rest of the system. We now try to move a file across two filesystems, using `rename()`. This isn't supported and therefore it fails. The solution is to manually copy the directory and delete the old one afterwards.

The problem here is, that this is much more complex, than simply calling a function. (Which is probably why #21 didn't get merged). For now I'm simply calling `mv /tmp/tldrxxxx/tldr-main ~/.tldrc/tldr`. This works perfectly on Linux and maybe on macOS, but probably not on Windows. [This] would be an example of a cross-platform copying function.

Since that exceeds my C knowledge I'm asking you what to do. Is this client even indented to work on Windows at all?