### PR TITLE
parse_tldrlist: propagate opendir fails instead of segfaulting

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -268,11 +268,13 @@ parse_tldrlist(char const *path, char const *platform)
     if (sstrncat(fullpath, &len, STRBUFSIZ, platform, strlen(platform)))
         return 1;
 
+    directory = opendir(fullpath);
+    if (directory == NULL)
+        return 1;
+
     fprintf(stdout, "%s", ANSI_BOLD_ON);
     fprintf(stdout, "Pages for %s\n", platform);
     fprintf(stdout, "%s", ANSI_BOLD_OFF);
-
-    directory = opendir(fullpath);
 
     while((entry = readdir(directory))) {
         len = strlen(entry->d_name);

--- a/src/parser.c
+++ b/src/parser.c
@@ -269,8 +269,10 @@ parse_tldrlist(char const *path, char const *platform)
         return 1;
 
     directory = opendir(fullpath);
-    if (directory == NULL)
+    if (directory == NULL) {
+        fprintf(stderr, "Can't open can't open cache directory.");
         return 1;
+    }
 
     fprintf(stdout, "%s", ANSI_BOLD_ON);
     fprintf(stdout, "Pages for %s\n", platform);

--- a/src/parser.c
+++ b/src/parser.c
@@ -270,7 +270,7 @@ parse_tldrlist(char const *path, char const *platform)
 
     directory = opendir(fullpath);
     if (directory == NULL) {
-        fprintf(stderr, "Can't open can't open cache directory.");
+        fprintf(stderr, "Can't open cache directory.");
         return 1;
     }
 


### PR DESCRIPTION
## What does it do?
Return 1, when `opendir` fails.

## Why the change?
Fixes segfaults.

## How can this be tested?
Reproduce #71, or `chown root:root ~/.tldrc && chmod 700 ~/.tldrc`.

## Relevant tickets?
While not fixing it, this does stop #71 from segfaulting.
