### PR TITLE
Fixed wrong cache directory name

### DIFF
--- a/src/local.c
+++ b/src/local.c
@@ -175,7 +175,7 @@ update_localdb(int verbose)
     outlen = 0;
     if (sstrncat(tmp, &outlen, STRBUFSIZ, outpath, strlen(outpath)))
         return 1;
-    if (sstrncat(tmp, &outlen, STRBUFSIZ, TLDR_DIR, TLDR_DIR_LEN))
+    if (sstrncat(tmp, &outlen, STRBUFSIZ, TLDR_ZIP_DIR, TLDR_ZIP_DIR_LEN))
         return 1;
 
     homedir = gethome();

--- a/src/tldr.h
+++ b/src/tldr.h
@@ -26,7 +26,10 @@
 #define TMP_FILE "/main.zip"
 #define TMP_FILE_LEN (sizeof(TMP_FILE) - 1)
 
-#define TLDR_DIR "/tldr-main" // this is the name of the directory inside `main.zip`
+#define TLDR_ZIP_DIR "/tldr-main"
+#define TLDR_ZIP_DIR_LEN (sizeof(TLDR_ZIP_DIR) - 1)
+
+#define TLDR_DIR "/tldr"
 #define TLDR_DIR_LEN (sizeof(TLDR_DIR) - 1)
 
 #define TLDR_HOME "/.tldrc"


### PR DESCRIPTION
## What does it do?
I added two new `#define`s called `TLDR_ZIP_DIR` and `TLDR_ZIP_DIR_LEN`, used them in `update_localdb` and changed `TLDR_DIR` back.

## Why the change?
While the directory in the ZIP has this different name, we assume the name of the extracted directory, for example in `TLDR_EXT`, to be `tldr`. This is what caused the segfaults.

## How can this be tested?
Try reproducing #71 or #74.
