### PR TITLE
Add some more basic integration tests to CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,5 +34,11 @@ jobs:
     - name: Compile
       run: make V=1 DEBUG= CC=${{ matrix.compiler }} LD=${{ matrix.compiler }}
 
-    - name: Test
+    - name: Test printing tldr version
       run: ./tldr --version
+      
+    - name: Test printing tldr list
+      run: ./tldr --list
+      
+    - name: Test printing tldr page
+      run: ./tldr tar


### PR DESCRIPTION
## What does it do?

Adds two new "integration tests" to the CI workflow to help test basic CLI usage.

## Why the change?

As shown in #71, a segfault slipped into the codebase. Adding this helps validate the behavior of the client. This acts as a small starting point to act as a place to prevent a regression on merging #75.

## How can this be tested?

Run CI tests

## Other notes

This should be merged after merging #75. A successful run of this action on top of #75 can be seen here: https://github.com/tldr-pages/tldr-c-client/actions/runs/1663299468