### PR TITLE
Bubble non-zero exit code from parse_tldrlist

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -245,13 +245,12 @@ print_tldrlist(char const *poverride)
         return 1;
 
     if (strcmp(platform, "common") != 0) {
-        parse_tldrlist(directory, platform);
+        if (parse_tldrlist(directory, platform))
+            return 1;
         fprintf(stdout, "\n");
     }
 
-    parse_tldrlist(directory, "common");
-
-    return 0;
+    return parse_tldrlist(directory, "common");
 }
 
 int


### PR DESCRIPTION
## What does it do?

Makes it so that `print_tldrlist` will appropriately return with a non-zero code if `parse_tldrlist` returns with non-zero, indicating an error has occurred.

## Why the change?

As pointed out in https://github.com/tldr-pages/tldr-c-client/pull/73#discussion_r780131544, with the change there (or any of the other error conditions), `tldr --list` will exit with no message to the user as well as a zero exit code, which is incorrect. While the state of error messaging should be improved, we should always be exiting with a non-zero exit code if an error has occurred.

## How can this be tested?

Introduce an error state in `parse_tldrlist` (or just add a `return 1;` at the top of the function), should see the tldr client exit with a 1 exit code.
