### PR TITLE
Fix database typo in the usage: `list all entries in the local databse`

### DIFF
--- a/src/tldr.c
+++ b/src/tldr.c
@@ -210,7 +210,7 @@ print_usage(char const *arg)
     fprintf(stdout, "    %-20s %-30s\n", "-h, --help", "print this help and exit");
     fprintf(stdout, "    %-20s %-30s\n", "-u, --update", "update local database");
     fprintf(stdout, "    %-20s %-30s\n", "-c, --clear-cache", "clear local database");
-    fprintf(stdout, "    %-20s %-30s\n", "-l, --list", "list all entries in the local databse");
+    fprintf(stdout, "    %-20s %-30s\n", "-l, --list", "list all entries in the local database");
     fprintf(stdout, "    %-20s %-30s\n", "-p, --platform=PLATFORM",
             "select platform, supported are linux / osx / sunos / windows / common");
     fprintf(stdout, "    %-20s %-30s\n", "--linux", "show command page for Linux");


### PR DESCRIPTION
## What does it do?
It fixes a typo in the usage, see `list all entries in the local databse` in:

```
$ tldr
usage: tldr [-v] [OPTION]... SEARCH

available commands:
    -v                   print verbose output
    --version            print version and exit
    -h, --help           print this help and exit
    -u, --update         update local database
    -c, --clear-cache    clear local database
    -l, --list           list all entries in the local databse
    -p, --platform=PLATFORM select platform, supported are linux / osx / sunos / windows / common
    --linux              show command page for Linux
    --osx                show command page for OSX
    --sunos              show command page for SunOS
    -r, --render=PATH    render a local page for testing purposes
```

```
tldr --version
tldr v1.4.3 (v1.4.3)
Copyright (C) 2016 Arvid Gerstmann
Source available at https://github.com/tldr-pages/tldr-c-client
```

## Why the change?
Typos should be avoided. 😉 

## How can this be tested?
Run `tldr` and check the output. 👁️ 

## Where to start code review?
Should be easy. 😉 

## Relevant tickets?
None.

## Questions?
No.
