### PR TITLE
Bump version to 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ Deprecated features will be kept for any following maintenance release, and
 will be removed after two major releases.
 
 ## [Unreleased]
+
+## v1.5.0 - 2022-07-03
 ### Added
 - Add fish completion for `--list`, `--linux`, `--osx`, and `--sunos` flags
+
 ### Fixed
+- Fix typo of "database" in the usage output
 - Fix fish completion not escaping characters
 - Make fish completion reflect actual usage of `tldr` better
 

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ endif
 HAS_GIT			:= $(shell type git > /dev/null 2>&1 && echo "1" || echo "0")
 IS_GITREPO		:= $(shell [ -d .git ] && echo "1" || echo "0")
 ifeq (0,$(filter 0,$(HAS_GIT) $(IS_GITREPO)))
-VER				:= v1.4.3
+VER				:= v1.5.0
 else
 VER				:= $(shell git describe --tags --always --dirty)
 endif

--- a/src/tldr.c
+++ b/src/tldr.c
@@ -13,7 +13,7 @@
 #include <string.h>
 #include <time.h>
 
-#define VERSION_TAG "v1.4.3"
+#define VERSION_TAG "v1.5.0"
 #ifndef VERSION
     #define VERSION_PRETTY ""
 #else


### PR DESCRIPTION
PR to prep for the release of 1.5.0, which features improved autocomplete stuff for fish, as well as a small typo fix. Given that there's nothing else in the works (to my knowledge), no reason to not cut the release now.