### PR TITLE
ci: upgrade GitHub actions to Node.js v16 🚒

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,9 +12,7 @@ jobs:
     name: Brew Formula
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
+      - uses: actions/checkout@v3
       - name: Update Homebrew Formula
         uses: dawidd6/action-homebrew-bump-formula@v3
         with:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,11 +7,8 @@ on:
 jobs:
   stale:
     runs-on: ubuntu-latest
-
     steps:
-
-    - name: Stale Bot
-      uses: actions/stale@v3
+    - uses: actions/stale@v5
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,8 +14,7 @@ jobs:
 
     steps:
 
-    - name: Checkout
-      uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
 


### PR DESCRIPTION
## What does it do?
Upgrade the GitHub Actions to versions with node16 as runtime.

## Why the change?
Node.js v12 is deprecated and the old versions use node12 as runtime.

## How can this be tested?
Running the GitHub workflows for this repo.

