### PR TITLE
Auto updating local data if too old

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ available commands:
 
 ## Configuration
 
-To prevent `tldr` from automatically updating its database, set the environment variable `TLDR_PREVENT_UPDATE`.
+To prevent `tldr` from automatically updating its database, set the environment variable `TLDR_AUTO_UPDATE_DISABLED`.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,9 @@ available commands:
     -r, --render=PATH    render a local page for testing purposes
 ```
 
+## Configuration
+
+To prevent `tldr` from automatically updating its database, set the environment variable `TLDR_PREVENT_UPDATE`.
 
 ## Contributing
 

--- a/src/local.c
+++ b/src/local.c
@@ -56,7 +56,10 @@ check_localdate(void)
         /* *INDENT-OFF* */
         fprintf(stdout, "%s", ANSI_BOLD_ON);
         fprintf(stdout, "%s", ANSI_COLOR_CODE_FG);
-        fprintf(stdout, "Local data is older than two weeks, use --update to update it.\n\n");
+        fprintf(stdout, "Local data is older than two weeks, attempting to automatically update it...\n");
+        if (update_localdb(0))
+            fprintf(stdout, "Failed to automatically update local data.\n");
+        fprintf(stdout, "\n");
         fprintf(stdout, "%s", ANSI_COLOR_RESET_FG);
         fprintf(stdout, "%s", ANSI_BOLD_OFF);
         /* *INDENT-ON* */

--- a/src/local.c
+++ b/src/local.c
@@ -52,18 +52,18 @@ check_localdate(void)
     curtime = time(NULL);
     oldtime = strtol(buffer, NULL, 10);
     difftime = curtime - oldtime;
-    if (difftime > (60 * 60 * 24 * 7 * 2)) {
-        /* *INDENT-OFF* */
-        fprintf(stdout, "%s", ANSI_BOLD_ON);
-        fprintf(stdout, "%s", ANSI_COLOR_CODE_FG);
-        fprintf(stdout, "Local data is older than two weeks, attempting to automatically update it...\n");
-        if (update_localdb(0))
-            fprintf(stdout, "Failed to automatically update local data.\n");
-        fprintf(stdout, "\n");
-        fprintf(stdout, "%s", ANSI_COLOR_RESET_FG);
-        fprintf(stdout, "%s", ANSI_BOLD_OFF);
-        /* *INDENT-ON* */
+if (difftime > (60 * 60 * 24 * 7 * 2) && !getenv(PREVENT_UPDATE_ENV_VARIABLE)) {
+    /* *INDENT-OFF* */
+    fprintf(stdout, "Local database is older than two weeks, attempting to update it...\n");
+    fprintf(stdout, "To prevent automatic updates, set the environment variable %s.\n", PREVENT_UPDATE_ENV_VARIABLE);
+    if (update_localdb(0)) {
+        fprintf(stdout, "%s%s", ANSI_BOLD_ON, ANSI_COLOR_CODE_FG);
+        fprintf(stdout, "Failed to update local database.\n");
+        fprintf(stdout, "%s%s", ANSI_COLOR_RESET_FG, ANSI_BOLD_OFF);
     }
+    fprintf(stdout, "\n");
+    /* *INDENT-ON* */
+}
 
     fclose(fp);
     return difftime;

--- a/src/local.c
+++ b/src/local.c
@@ -52,18 +52,18 @@ check_localdate(void)
     curtime = time(NULL);
     oldtime = strtol(buffer, NULL, 10);
     difftime = curtime - oldtime;
-if (difftime > (60 * 60 * 24 * 7 * 2) && !getenv(PREVENT_UPDATE_ENV_VARIABLE)) {
-    /* *INDENT-OFF* */
-    fprintf(stdout, "Local database is older than two weeks, attempting to update it...\n");
-    fprintf(stdout, "To prevent automatic updates, set the environment variable %s.\n", PREVENT_UPDATE_ENV_VARIABLE);
-    if (update_localdb(0)) {
-        fprintf(stdout, "%s%s", ANSI_BOLD_ON, ANSI_COLOR_CODE_FG);
-        fprintf(stdout, "Failed to update local database.\n");
-        fprintf(stdout, "%s%s", ANSI_COLOR_RESET_FG, ANSI_BOLD_OFF);
+    if (difftime > (60 * 60 * 24 * 7 * 2) && !getenv(PREVENT_UPDATE_ENV_VARIABLE)) {
+        /* *INDENT-OFF* */
+        fprintf(stdout, "Local database is older than two weeks, attempting to update it...\n");
+        fprintf(stdout, "To prevent automatic updates, set the environment variable %s.\n", PREVENT_UPDATE_ENV_VARIABLE);
+        if (update_localdb(0)) {
+            fprintf(stdout, "%s%s", ANSI_BOLD_ON, ANSI_COLOR_CODE_FG);
+            fprintf(stdout, "Failed to update local database.\n");
+            fprintf(stdout, "%s%s", ANSI_COLOR_RESET_FG, ANSI_BOLD_OFF);
+        }
+        fprintf(stdout, "\n");
+        /* *INDENT-ON* */
     }
-    fprintf(stdout, "\n");
-    /* *INDENT-ON* */
-}
 
     fclose(fp);
     return difftime;

--- a/src/parser.c
+++ b/src/parser.c
@@ -194,21 +194,24 @@ print_tldrpage(char const *input, char const *poverride)
         }
     }
 
-    construct_url(url, URLBUFSIZ, input, platform);
+    if (!getenv(PREVENT_UPDATE_ENV_VARIABLE)) {
+        construct_url(url, URLBUFSIZ, input, platform);
 
-    /* make clang's static analyzer happy */
-    output = NULL;
-    download_content(url, &output, 0);
-    if (output == NULL) {
-        construct_url(url, URLBUFSIZ, input, "common");
+        /* make clang's static analyzer happy */
+        output = NULL;
         download_content(url, &output, 0);
-        if (output == NULL)
-            return 1;
+        if (output == NULL) {
+            construct_url(url, URLBUFSIZ, input, "common");
+            download_content(url, &output, 0);
+            if (output == NULL)
+                return 1;
+        }
+
+        parse_tldrpage(output);
+
+        free(output);
     }
-
-    parse_tldrpage(output);
-
-    free(output);
+    
     return 0;
 }
 

--- a/src/parser.c
+++ b/src/parser.c
@@ -195,7 +195,7 @@ print_tldrpage(char const *input, char const *poverride)
     }
 
     if (getenv(PREVENT_UPDATE_ENV_VARIABLE))
-    return 1;
+        return 1;
 
     construct_url(url, URLBUFSIZ, input, platform);
 

--- a/src/parser.c
+++ b/src/parser.c
@@ -194,24 +194,25 @@ print_tldrpage(char const *input, char const *poverride)
         }
     }
 
-    if (!getenv(PREVENT_UPDATE_ENV_VARIABLE)) {
-        construct_url(url, URLBUFSIZ, input, platform);
+    if (getenv(PREVENT_UPDATE_ENV_VARIABLE))
+    return 1;
 
-        /* make clang's static analyzer happy */
-        output = NULL;
+    construct_url(url, URLBUFSIZ, input, platform);
+
+    /* make clang's static analyzer happy */
+    output = NULL;
+    download_content(url, &output, 0);
+    if (output == NULL) {
+        construct_url(url, URLBUFSIZ, input, "common");
         download_content(url, &output, 0);
-        if (output == NULL) {
-            construct_url(url, URLBUFSIZ, input, "common");
-            download_content(url, &output, 0);
-            if (output == NULL)
-                return 1;
-        }
-
-        parse_tldrpage(output);
-
-        free(output);
+        if (output == NULL)
+            return 1;
     }
-    
+
+    parse_tldrpage(output);
+
+    free(output);
+
     return 0;
 }
 

--- a/src/tldr.c
+++ b/src/tldr.c
@@ -177,6 +177,10 @@ main(int argc, char **argv)
         if (print_tldrpage(buf, pbuf[0] != 0 ? pbuf : NULL)) {
             fprintf(stdout, "This page doesn't exist yet!\n");
             fprintf(stdout, "Submit new pages here: https://github.com/tldr-pages/tldr\n");
+            if (getenv(PREVENT_UPDATE_ENV_VARIABLE)) {
+                fprintf(stdout, "Checking the online database was skipped because automatic updates are disabled.\n");
+                fprintf(stdout, "You could try updating the local database manually with: tldr --update\n");
+            }
             return EXIT_FAILURE;
         }
     }

--- a/src/tldr.h
+++ b/src/tldr.h
@@ -41,7 +41,7 @@
 #define TLDR_EXT "/.tldrc/tldr/pages/"
 #define TLDR_EXT_LEN (sizeof(TLDR_EXT) - 1)
 
-#define PREVENT_UPDATE_ENV_VARIABLE "TLDR_PREVENT_UPDATE"
+#define PREVENT_UPDATE_ENV_VARIABLE "TLDR_AUTO_UPDATE_DISABLED"
 
 #define ANSI_COLOR_RESET_FG                     "\x1b[39m"
 #define ANSI_COLOR_TITLE_FG                     "\x1b[39m"

--- a/src/tldr.h
+++ b/src/tldr.h
@@ -41,6 +41,8 @@
 #define TLDR_EXT "/.tldrc/tldr/pages/"
 #define TLDR_EXT_LEN (sizeof(TLDR_EXT) - 1)
 
+#define PREVENT_UPDATE_ENV_VARIABLE "TLDR_PREVENT_UPDATE"
+
 #define ANSI_COLOR_RESET_FG                     "\x1b[39m"
 #define ANSI_COLOR_TITLE_FG                     "\x1b[39m"
 #define ANSI_COLOR_EXPLANATION_FG               "\x1b[39m"


### PR DESCRIPTION
## What does it do?
If the local data is too old, it now no longer asks you to manually update it but attempts to automatically do so. Regardless of whether it succeeds, the output is shown.


## Why the change?
It is annoying to manually update it. See also #81.


## How can this be tested?
Change the date in `~/.tldrc/date` to something further back than the past two weeks, run any `tldr` command like `tldr tldr`


## Where to start code review?
Very few lines changed in `local.c`


## Relevant tickets?
Closes #81.


## Questions?
This is just a first attempt. If you'd like me to change how this is implemented, I will gladly do that. I just wanted to start the conversation.

