### PR TITLE
chore: add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.c]
+indent_size = 4
+
+[*.{markdown,md}]
+trim_trailing_whitespace = false

--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ folder in the root of the repository.
 
 #### Installation
 
-To install the autocompletion, just move the script for your shell to an easy-to-access
-directory (like your home directory), and source it in your `.bashrc` or `.zshrc`.
+To install the autocompletion, just move the script for your shell to an easy
+to access directory (like your home directory), and source it in your `.bashrc` or `.zshrc`.
 
 Example for zsh:
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A command line client for tldr, written in plain ISO C90.
 
 ## Installing
 
-On OS X, the client can be installed through [homebrew](http://brew.sh/).
+On OS X, the client can be installed through [Homebrew](http://brew.sh/).
 
 ```shell
 # To install latest development version
@@ -70,8 +70,8 @@ folder in the root of the repository.
 
 #### Installation
 
-To install the autocompletion, just move the script for your shell to a an easy
-to access directory (like your home directory), and source it in your `.bashrc` or `.zshrc`.
+To install the autocompletion, just move the script for your shell to an easy-to-access
+directory (like your home directory), and source it in your `.bashrc` or `.zshrc`.
 
 Example for zsh:
 


### PR DESCRIPTION
## What does it do?
* Adds .editorconfig file.
* Fix some typos in the README.
  * Homebrew is a noun, preserve capitalization.
  * "a an", only one of these is required, not both.


## Why the change?
EditorConfig is an editor/vendor agnostic configuration file to make following project conventions easier. Afaik (at least looking at the largest C projects on GitHub) there aren't clear conventions on things like indentation.

Rather than having to find out manually what a project uses, or just choosing to fight with my editor preferences, I think it'd be better to use a conventional format that most editors support to handle it.

Reviewers shouldn't need to put out comments like:

> Please adjust your editor settings to keep the current formatting.
> 
> — https://github.com/tldr-pages/tldr-c-client/pull/9#issuecomment-168494209


## How can this be tested?
N/A


## Where to start code review?
N/A


## Relevant tickets?
N/A


## Questions?
N/A

