### PR TITLE
chore: bump version to 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ will be removed after two major releases.
 ## v1.6.0 - 2023-05-03
 
 - Fix make finding lib directories with M1 Homebrew
-- Add support for Auto updating local data if too old
+- Add support for auto updating local data if too old
 
 ## v1.5.0 - 2022-07-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,15 @@ will be removed after two major releases.
 
 ## [Unreleased]
 
-## v1.6.0 - 2023-05-03
+## v1.6.0 - 2023-05-09
+
+### Added
+
+- Add support for auto updating local data if too old
+
+### Fixed
 
 - Fix make finding lib directories with M1 Homebrew
-- Add support for auto updating local data if too old
 
 ## v1.5.0 - 2022-07-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,31 +8,47 @@ will be removed after two major releases.
 
 ## [Unreleased]
 
+## v1.6.0 - 2023-05-03
+
+- Fix make finding lib directories with M1 Homebrew
+- Add support for Auto updating local data if too old
+
 ## v1.5.0 - 2022-07-03
+
 ### Added
+
 - Add fish completion for `--list`, `--linux`, `--osx`, and `--sunos` flags
 
 ### Fixed
+
 - Fix typo of "database" in the usage output
 - Fix fish completion not escaping characters
 - Make fish completion reflect actual usage of `tldr` better
 
 ## v1.4.3 - 2022-04-11
+
 ### Fixed
+
 - Fix segfault on trying to update cache
 - Fix segfault when failing to open cache directory
 - Bubble error code appropriately when using `--list`
 
 ## v1.4.2 - 2021-11-13
+
 ### Fixed
+
 - Fix version not being updated in source code
 
 ## v1.4.1 - 2021-11-12
+
 ### Fixed
+
 - Fix wrong directory name when extracting files from zip cache download
 
 ## v1.4.0 - 2021-11-07
+
 ### Added
+
 - Add fish completion (see README.md for details)
 - Improve output messages for various options
 - Add `--list option`
@@ -42,6 +58,7 @@ will be removed after two major releases.
 - Add yum support to the `./deps.sh` script
 
 ### Fixed
+
 - Do not check last cache update date when updating cache
 - Add yes flag to apt install in ./deps.sh script
 - Add blank line at end of output
@@ -49,36 +66,43 @@ will be removed after two major releases.
 - Use `tldr` instead of `tldr-pages` as name for cache folder
 
 ### Miscellaneous
+
 - Rename repository from `tldr-cpp-client` to `tldr-c-client`
 - Move from Travis-CI to GitHub actions
 
 ## v1.3.0 - 2016-09-09
+
 ### Added
+
 - Initial release in core homebrew repository
 - Add zsh / bash completion (see README.md for details)
 
 ### Fixed
+
 - Fix compiling on old Linux distributions
 
 
 ## v1.2.0 - 2016-04-06
+
 ### Added
+
 - Download local database at first run
 - Add SunOS as supported tldr platform
 - Add --clear-cache option, to clear the local database
 
-
 ## v1.1.0 - 2016-01-18
+
 ### Added
+
 - Error messages
 
 ### Fixed
+
 - Typos
 
-
 ## v1.0.0 - 2015-12-30
-- Initial release
 
+- Initial release
 
 <!-- This is an example how a section should look like:
 
@@ -102,4 +126,3 @@ will be removed after two major releases.
 - Mentioning any security vulnarabilities
 
 -->
-

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ endif
 HAS_GIT			:= $(shell type git > /dev/null 2>&1 && echo "1" || echo "0")
 IS_GITREPO		:= $(shell [ -d .git ] && echo "1" || echo "0")
 ifeq (0,$(filter 0,$(HAS_GIT) $(IS_GITREPO)))
-VER				:= v1.5.0
+VER				:= v1.6.0
 else
 VER				:= $(shell git describe --tags --always --dirty)
 endif

--- a/src/tldr.c
+++ b/src/tldr.c
@@ -13,7 +13,7 @@
 #include <string.h>
 #include <time.h>
 
-#define VERSION_TAG "v1.5.0"
+#define VERSION_TAG "v1.6.0"
 #ifndef VERSION
     #define VERSION_PRETTY ""
 #else


### PR DESCRIPTION
## Changes

- Bump version to `1.6.0`.
- Update CHANGELOG and fix formatting to almost conform with Markdown lint.


Note: This is a preparatory PR like #88, once merged I will tag and create a new release and update it in Homebrew.