### PR TITLE
Fix: prevent freezing of autocomplete in Zsh

### DIFF
--- a/autocomplete/complete.zsh
+++ b/autocomplete/complete.zsh
@@ -8,7 +8,7 @@
 
 _tldr_get_files() {
 	local ret
-	local files="$(find $HOME/.tldrc/tldr/pages/$1 -name '*.md' -exec basename {} .md \;)"
+	local files="$(find $HOME/.tldrc/tldr/pages/$1 -name '*.md' -exec basename -s .md {} +)"
 
 	IFS=$'\n\t'
 	for f in $files; do


### PR DESCRIPTION
Collects all pages using single invocation of base name instead of invoking basename for all individual page


## What does it do?
Replaces multiple (now 2400+) invocations of `basename` with the single one.


## Why the change?
Change prevents freezing of console when user presses `<TAB>` by dramatically decreasing time to lookup page files:

Before:
```
❯ time find $HOME/.tldrc/tldr/pages/common -name '*.md' -exec basename {} .md \; >/dev/null                                      
find $HOME/.tldrc/tldr/pages/common -name '*.md' -exec basename {} .md \; >   1.51s user 3.58s system 36% cpu 14.076 total
```

After:
```
❯ time find $HOME/.tldrc/tldr/pages/common -name '*.md' -exec basename -s .md {} + >/dev/null                                    
find $HOME/.tldrc/tldr/pages/common -name '*.md' -exec basename -s .md {} + >  0.00s user 0.01s system 22% cpu 0.047 total
```

## How can this be tested?
Change can be tested by invoking autocompletion in Zsh: enter `tldr ` and press _tab_ key.
Zsh autocomplete file should be sourced before testing: `source autocomplete/complete.zsh`


## Where to start code review?
Single line change so it is self-explanatory


## Relevant tickets?
None


## Questions?
None

