### PR TITLE
add option --color and do not show colors when the output is not a tty

### DIFF
--- a/man/tldr.1
+++ b/man/tldr.1
@@ -33,6 +33,9 @@ select platform, supported are \fIlinux\fR / \fIosx\fR / \fIsunos\fR / \fIwindow
 .TP
 .BR \-r ", " \-\-render=\fIPATH\fR
 render a local page for testing purposes
+.TP
+.BR \-C ", " \-\-color
+force color display even if the output is not a tty
 .SH EXIT STATUS
 0 on success, any other positive value otherwise
 .SH SEE ALSO

--- a/src/parser.c
+++ b/src/parser.c
@@ -59,8 +59,9 @@ construct_path(char *buf, size_t buflen, char const *home, char const *input,
 }
 
 int
-parse_tldrpage(char const *input)
+parse_tldrpage(char const *input, int print_color)
 {
+#define WHEN_COLOR if (print_color)
     char c;
     int i, len;
     int start = -1;
@@ -74,40 +75,40 @@ parse_tldrpage(char const *input)
             switch (c) {
             case '>':
                 start = i;
-                fprintf(stdout, "%s", ANSI_COLOR_EXPLANATION_FG);
+                WHEN_COLOR fprintf(stdout, "%s", ANSI_COLOR_EXPLANATION_FG);
                 continue;
 
             case '-':
                 start = i;
-                fprintf(stdout, "%s", ANSI_COLOR_COMMENT_FG);
+                WHEN_COLOR fprintf(stdout, "%s", ANSI_COLOR_COMMENT_FG);
                 continue;
 
             case '`':
                 start = i;
-                fprintf(stdout, "%s", ANSI_COLOR_CODE_FG);
+                WHEN_COLOR fprintf(stdout, "%s", ANSI_COLOR_CODE_FG);
                 fprintf(stdout, "    ");
                 continue;
 
             case '#':
                 start = i;
-                fprintf(stdout, "%s", ANSI_BOLD_ON);
-                fprintf(stdout, "%s", ANSI_COLOR_TITLE_FG);
+                WHEN_COLOR fprintf(stdout, "%s", ANSI_BOLD_ON);
+                WHEN_COLOR fprintf(stdout, "%s", ANSI_COLOR_TITLE_FG);
                 continue;
             }
         } else if (start > -1) {
             if (input[i] == '{' && input[i + 1] == '{') {
                 fprintf(stdout, "%.*s", i - (start + 1), input + (start + 1));
-                fprintf(stdout, "%s", ANSI_BOLD_OFF);
-                fprintf(stdout, "%s", ANSI_COLOR_RESET_FG);
-                fprintf(stdout, "%s", ANSI_COLOR_CODE_PLACEHOLDER_FG);
+                WHEN_COLOR fprintf(stdout, "%s", ANSI_BOLD_OFF);
+                WHEN_COLOR fprintf(stdout, "%s", ANSI_COLOR_RESET_FG);
+                WHEN_COLOR fprintf(stdout, "%s", ANSI_COLOR_CODE_PLACEHOLDER_FG);
 
                 start = i;
                 for (i = i + 1; i < len; i++) {
                     if (input[i] == '}' && input[i + 1] == '}') {
                         fprintf(stdout, "%.*s", i - (start + 2),
                                 input + (start + 2));
-                        fprintf(stdout, "%s", ANSI_COLOR_RESET_FG);
-                        fprintf(stdout, "%s", ANSI_COLOR_CODE_FG);
+                        WHEN_COLOR fprintf(stdout, "%s", ANSI_COLOR_RESET_FG);
+                        WHEN_COLOR fprintf(stdout, "%s", ANSI_COLOR_CODE_FG);
                         start = i + 1;
                         break;
                     }
@@ -128,8 +129,8 @@ parse_tldrpage(char const *input)
                 fprintf(stdout, "%.*s\n", i - (start + 2), input + (start + 2));
             }
 
-            fprintf(stdout, "%s", ANSI_BOLD_OFF);
-            fprintf(stdout, "%s", ANSI_COLOR_RESET_FG);
+            WHEN_COLOR fprintf(stdout, "%s", ANSI_BOLD_OFF);
+            WHEN_COLOR fprintf(stdout, "%s", ANSI_COLOR_RESET_FG);
             fprintf(stdout, "\n");
             start = -1;
         }
@@ -137,10 +138,11 @@ parse_tldrpage(char const *input)
 
     fprintf(stdout, "\n");
     return 0;
+#undef WHEN_COLOR
 }
 
 int
-print_tldrpage(char const *input, char const *poverride)
+print_tldrpage(char const *input, char const *poverride, int color)
 {
     char *output;
     char url[URLBUFSIZ];
@@ -178,7 +180,7 @@ print_tldrpage(char const *input, char const *poverride)
         construct_path(url, URLBUFSIZ, homedir, input, platform);
         if (stat(url, &sb) == 0 && S_ISREG(sb.st_mode)) {
             if (!get_file_content(url, &output, 0)) {
-                parse_tldrpage(output);
+                parse_tldrpage(output, color);
                 free(output);
                 return 0;
             }
@@ -186,7 +188,7 @@ print_tldrpage(char const *input, char const *poverride)
             construct_path(url, URLBUFSIZ, homedir, input, "common");
             if (stat(url, &sb) == 0 && S_ISREG(sb.st_mode)) {
                 if (!get_file_content(url, &output, 0)) {
-                    parse_tldrpage(output);
+                    parse_tldrpage(output, color);
                     free(output);
                     return 0;
                 }
@@ -209,7 +211,7 @@ print_tldrpage(char const *input, char const *poverride)
             return 1;
     }
 
-    parse_tldrpage(output);
+    parse_tldrpage(output, color);
 
     free(output);
 
@@ -293,11 +295,11 @@ parse_tldrlist(char const *path, char const *platform)
 }
 
 int
-print_localpage(char const *path)
+print_localpage(char const *path, int color)
 {
     char *output = NULL;
     if (!get_file_content(path, &output, 0)) {
-        parse_tldrpage(output);
+        parse_tldrpage(output, color);
         free(output);
         return 0;
     }

--- a/src/tldr.c
+++ b/src/tldr.c
@@ -33,6 +33,7 @@ static int clear_flag;
 static int platform_flag;
 static int list_flag;
 static int render_flag;
+static int color_flag;
 static char pbuf[STRBUFSIZ];
 static struct option long_options[] = {
     { "help", no_argument, &help_flag, 1 },
@@ -46,7 +47,8 @@ static struct option long_options[] = {
     { "osx",  no_argument, 0, 'p' },
     { "sunos",  no_argument, 0, 'p' },
     { "list", no_argument, &list_flag, 'l'},
-    { "render", required_argument, 0, 'r'}, {0, 0, 0, 0 }
+    { "render", required_argument, 0, 'r'},
+    { "color", no_argument, &color_flag, 'C' }, {0, 0, 0, 0 }
 };
 
 int
@@ -60,6 +62,9 @@ main(int argc, char **argv)
         print_usage(argv[0]);
         return EXIT_FAILURE;
     }
+
+    /* show colors when the output is a tty */
+    color_flag = isatty(fileno(stdout));
 
     while (1) {
         option_index = 0;
@@ -108,6 +113,10 @@ main(int argc, char **argv)
             render_flag = 1;
         } break;
 
+        case 'C': {
+            color_flag = 1;
+        } break;
+
         default:
             abort();
         }
@@ -150,7 +159,7 @@ main(int argc, char **argv)
         return EXIT_SUCCESS;
     }
     if (render_flag) {
-        if (print_localpage(pbuf))
+        if (print_localpage(pbuf, 1))
             return EXIT_FAILURE;
         return EXIT_SUCCESS;
     }
@@ -174,7 +183,7 @@ main(int argc, char **argv)
 
         if (!has_localdb())
             update_localdb(verbose_flag);
-        if (print_tldrpage(buf, pbuf[0] != 0 ? pbuf : NULL)) {
+        if (print_tldrpage(buf, pbuf[0] != 0 ? pbuf : NULL, color_flag)) {
             fprintf(stdout, "This page doesn't exist yet!\n");
             fprintf(stdout, "Submit new pages here: https://github.com/tldr-pages/tldr\n");
             if (getenv(PREVENT_UPDATE_ENV_VARIABLE)) {
@@ -222,6 +231,8 @@ print_usage(char const *arg)
     fprintf(stdout, "    %-20s %-30s\n", "--sunos", "show command page for SunOS");
     fprintf(stdout, "    %-20s %-30s\n", "-r, --render=PATH",
             "render a local page for testing purposes");
+    fprintf(stdout, "    %-20s %-30s\n", "-C, --color",
+            "force color display");
     /* *INDENT-ON* */
 }
 

--- a/src/tldr.h
+++ b/src/tldr.h
@@ -71,11 +71,11 @@ int         construct_url           (char *buf, size_t buflen,
                                      char const *platform);
 int         construct_path          (char *buf, size_t buflen, char const *home,
                                      char const *input, char const *platform);
-int         parse_tldrpage          (char const *input);
-int         print_tldrpage          (char const *input, char const *platform);
+int         parse_tldrpage          (char const *input, int color);
+int         print_tldrpage          (char const *input, char const *platform, int color);
 int         print_tldrlist          (char const *platform);
 int         parse_tldrlist          (char const *path, char const *platform);
-int         print_localpage         (char const *path);
+int         print_localpage         (char const *path, int color);
 
 /* utils.c */
 #define RMOPT_IGNORE_NOFILE     (0x1)


### PR DESCRIPTION
## What does it do?
Disable color display when the output is not a tty.

This change should not break the current workflow when tldr is used in terminals, but perhaps can break some CI runs (though unlikely), or perhaps someone's Emacs config that assumes color output.  In that case, the users can pass `--color` to force color output to get the old behavior.


## Why the change?
For example, when I call in emacs `M-! RET tldr <cmd> RET`, the display is very unreadable.

<img width="845" alt="image" src="https://github.com/tldr-pages/tldr-c-client/assets/23358293/edf904c4-4633-4881-b0b1-ef53fe963728">

After the change:

<img width="842" alt="image" src="https://github.com/tldr-pages/tldr-c-client/assets/23358293/1c72883c-ecab-4edb-b9dc-242bc1ea4e8e">

See also #35.

## How can this be tested?
1. `tldr cmd > file` : no color
2. `tldr cmd` : has color
3. `tldr --color cmd > file` : has color
4. `tldr cmd | cat` : no color
5. `tldr --color cmd | cat` : has color


## Where to start code review?
getopt options, and `color_flag`


## Relevant tickets?
#35


## Questions?
It is unclear whether to pass `color_flag` to `print_localpage`. For now, I simply passed 1 to preserve compatibility.

