### PR TITLE
Implement short flags and remove --linux, --osx, --sunos

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A command line client for tldr, written in plain ISO C90.
 
 On OS X, the client can be installed through [Homebrew](http://brew.sh/).
 
-```shell
+```sh
 # To install the latest development version
 brew install tldr --HEAD
 
@@ -18,13 +18,13 @@ brew install tldr
 
 On Arch Linux, the client can be installed through [the AUR](https://aur.archlinux.org/packages/tldr-git) using an AUR helper such as yay.
 
-```shell
+```sh
 yay -S tldr-git
 ```
 
 To build the latest version from the source:
 
-```shell
+```sh
 git clone https://github.com/tldr-pages/tldr-c-client.git
 cd tldr-c-client
 
@@ -35,7 +35,7 @@ sudo make install        # install tldr
 
 To remove the version installed from the source:
 
-```shell
+```sh
 sudo make uninstall
 ```
 
@@ -60,7 +60,7 @@ in the root directory has all you need for building the project.
 
 Just call `make` and `tldr` will build itself.
 
-```shell
+```sh
 make
 ```
 
@@ -79,29 +79,26 @@ to access the directory (like your home directory), and source it in your `.bash
 
 Example for zsh:
 
-```shell
+```sh
 mv autocomplete/complete.zsh ~/.tldr.complete
 echo "source ~/.tldr.complete" >> ~/.zshrc
 ```
 
 ## Usage
 
-```shell
-usage: tldr [-v] [OPTION]... SEARCH
+```sh
+usage: tldr [OPTION]... PAGE
 
 available commands:
-    -v                   print verbose output          
-    --version            print version and exit        
-    -h, --help           print this help and exit      
-    -u, --update         update local database         
-    -c, --clear-cache    clear local database          
-    -l, --list           list all entries in the local database
+    -h, --help              print this help and exit
+    -C, --color             force color display
     -p, --platform=PLATFORM select platform, supported are linux / osx / sunos / windows / common
-    --linux              show command page for Linux   
-    --osx                show command page for OSX     
-    --sunos              show command page for SunOS   
-    -r, --render=PATH    render a local page for testing purposes
-    -C, --color          force color display
+    -r, --render=PATH       render a local page for testing purposes
+    -u, --update            update local database
+    -v, --version           print version and exit
+    -c, --clear-cache       clear local database
+    -V, --verbose           display verbose output (when used with --clear-cache or --update)
+    -l, --list              list all entries in the local database
 ```
 
 ## Configuration

--- a/man/tldr.1
+++ b/man/tldr.1
@@ -1,15 +1,17 @@
 .\" Manpage for tldr.
 .\" Contact ag@arvid.io to correct errors or typos.
-.mso www.tmac
 .TH TLDR 1
 .SH NAME
 tldr \- A collection of simplified and community-driven man pages.
 .SH SYNOPSIS
 .B tldr
-[\fB\-C\fR] [\fB\-v\fR] [\fB\-\-clear-cache\fR] [\fB\-\-update\fR] [\fB\-\-list\fR] [\fB\-p\fR \fIPLATFORM\fR]... [\fB\-r\fR \fIPATH\fR] \fIPAGE\fR
+[\fB\-C\fR] [\fB\-v\fR] [\fB\-c\fR] [\fB\-u\fR] [\fB\-l\fR] [\fB\-p\fR \fIPLATFORM\fR]... [\fB\-r\fR \fIPATH\fR] \fIPAGE\fR
 .SH DESCRIPTION
 tldr is a collection of simplified and community-driven man pages for commonly used command-line tools.
 .SH OPTIONS
+.TP
+.BR \-h ", " \-\-help
+Print help to standard output and exit.
 .TP
 .BR \-C ", " \-\-color
 Force color display.
@@ -26,23 +28,14 @@ Select platform, supported platforms are \fIlinux\fR / \fIosx\fR / \fIsunos\fR /
 .BR \-r ", " \-\-render=\fIPATH\fR
 Render a local page for testing purposes.
 .TP
-.BR \-\-clear-cache
+.BR \-c ", " \-\-clear-cache
 Remove the local database and exit.
 .TP
-.BR \-\-linux
-Show command page for Linux.
-.TP
-.BR \-\-list
+.BR \-l ", " \-\-list
 List all entries in the local database.
 .TP
-.BR \-\-osx
-Show command page for OSX.
-.TP
-.BR \-\-sunos
-Show command page for SunOS.
-.TP
-.BR \-\-verbose
-Print verbose output (when used with \fB\-\-clear-cache\fR or \fB\-\-update\fR).
+.BR \-V ", " \-\-verbose
+Print verbose output (when used with \fB\-c\fR or \fB\-u\fR).
 .SH EXIT STATUS
 0 on success, any other positive value otherwise.
 .SH SEE ALSO

--- a/src/tldr.c
+++ b/src/tldr.c
@@ -37,19 +37,17 @@ static int render_flag;
 static int color_flag;
 static char pbuf[STRBUFSIZ];
 static struct option long_options[] = {
-    {"help", no_argument, &help_flag, 'h'},
-    {"version", no_argument, &version_flag, 'v'},
-    {"verbose", no_argument, &verbose_flag, 'V'},
-    {"update", no_argument, &update_flag, 'u'},
-    {"clear-cache", no_argument, &clear_flag, 'c'},
+    {"help", no_argument, &help_flag, 1},
+    {"version", no_argument, &version_flag, 1},
+    {"verbose", no_argument, &verbose_flag, 1},
+    {"update", no_argument, &update_flag, 1},
+    {"clear-cache", no_argument, &clear_flag, 1},
     {"platform", required_argument, 0, 'p'},
-    {"linux", no_argument, 0, 'p'},
-    {"osx", no_argument, 0, 'p'},
-    {"sunos", no_argument, 0, 'p'},
-    {"list", no_argument, &list_flag, 'l'},
+    {"list", no_argument, &list_flag, 1},
     {"render", required_argument, 0, 'r'},
-    {"color", no_argument, &color_flag, 'C'},
-    {0, 0, 0, 0}};
+    {"color", no_argument, &color_flag, 1},
+    { 0 }
+};
 
 int main(int argc, char **argv) {
     int c;
@@ -70,7 +68,7 @@ int main(int argc, char **argv) {
 
     while (1) {
         option_index = 0;
-        c = getopt_long_only(argc, argv, "hvVucp:lr:C", long_options, &option_index);
+        c = getopt_long(argc, argv, "hvVucp:lr:C", long_options, &option_index);
 
         /* reached the end, bail out */
         if (c == -1) {
@@ -91,20 +89,10 @@ int main(int argc, char **argv) {
             return EXIT_FAILURE;
             break;
 
-        case 'p': {
-            const char *platform_name = long_options[option_index].name;
-            if (strcmp(platform_name, "platform") == 0) {
-                size_t len = strlen(optarg);
-                if (len > STRBUFSIZ)
-                    exit(EXIT_FAILURE);
-
-                memcpy(pbuf, optarg, len);
-                pbuf[len] = '\0';
-            } else {
-                memcpy(pbuf, platform_name, strlen(platform_name));
-            }
+        case 'p':
+            memcpy(pbuf, optarg, strlen(optarg));
             platform_flag = 1;
-        } break;
+            break;
 
         case 'r': {
             size_t len = strlen(optarg);
@@ -236,13 +224,13 @@ void print_version(char const *arg) {
 }
 
 void print_usage(char const *arg){
-    char const *out = "usage: %s [--verbose] [OPTION]... [PAGE]\n\n";
+    char const *out = "usage: %s [OPTION]... PAGE\n\n";
 
     /* *INDENT-OFF* */
     fprintf(stdout, out, arg);
     fprintf(stdout, "available commands:\n");
-    fprintf(stdout, "    %-23s %s\n", "-C, --color", "force color display");
     fprintf(stdout, "    %-23s %s\n", "-h, --help", "print this help and exit");
+    fprintf(stdout, "    %-23s %s\n", "-C, --color", "force color display");
     fprintf(stdout, "    %-23s %s\n", "-p, --platform=PLATFORM",
             "select platform, supported are linux / osx / sunos / windows / common");
     fprintf(stdout, "    %-23s %s\n", "-r, --render=PATH",
@@ -252,8 +240,5 @@ void print_usage(char const *arg){
     fprintf(stdout, "    %-23s %s\n", "-c, --clear-cache", "clear local database");
     fprintf(stdout, "    %-23s %s\n", "-V, --verbose", "display verbose output (when used with --clear-cache or --update)");
     fprintf(stdout, "    %-23s %s\n", "-l, --list", "list all entries in the local database");
-    fprintf(stdout, "    %-23s %s\n", "--linux", "show command page for Linux");
-    fprintf(stdout, "    %-23s %s\n", "--osx", "show command page for OSX");
-    fprintf(stdout, "    %-23s %s\n", "--sunos", "show command page for SunOS");
     /* *INDENT-ON* */
 }

--- a/src/tldr.c
+++ b/src/tldr.c
@@ -37,11 +37,11 @@ static int render_flag;
 static int color_flag;
 static char pbuf[STRBUFSIZ];
 static struct option long_options[] = {
-    {"help", no_argument, &help_flag, 1},
-    {"version", no_argument, &version_flag, 1},
-    {"verbose", no_argument, &verbose_flag, 1},
-    {"update", no_argument, &update_flag, 1},
-    {"clear-cache", no_argument, &clear_flag, 1},
+    {"help", no_argument, &help_flag, 'h'},
+    {"version", no_argument, &version_flag, 'v'},
+    {"verbose", no_argument, &verbose_flag, 'V'},
+    {"update", no_argument, &update_flag, 'u'},
+    {"clear-cache", no_argument, &clear_flag, 'c'},
     {"platform", required_argument, 0, 'p'},
     {"linux", no_argument, 0, 'p'},
     {"osx", no_argument, 0, 'p'},
@@ -70,7 +70,7 @@ int main(int argc, char **argv) {
 
     while (1) {
         option_index = 0;
-        c = getopt_long_only(argc, argv, "vp:r:C", long_options, &option_index);
+        c = getopt_long_only(argc, argv, "hvVucp:lr:C", long_options, &option_index);
 
         /* reached the end, bail out */
         if (c == -1) {
@@ -118,6 +118,26 @@ int main(int argc, char **argv) {
 
         case 'C':
             color_flag = 1;
+            break;
+
+        case 'h':
+            help_flag = 1;
+            break;
+
+        case 'l':
+            list_flag = 1;
+            break;
+
+        case 'V':
+            verbose_flag = 1;
+            break;
+
+        case 'u':
+            update_flag = 1;
+            break;
+
+        case 'c':
+            clear_flag = 1;
             break;
 
         default:
@@ -229,9 +249,9 @@ void print_usage(char const *arg){
             "render a local page for testing purposes");
     fprintf(stdout, "    %-23s %s\n", "-u, --update", "update local database");
     fprintf(stdout, "    %-23s %s\n", "-v, --version", "print version and exit");
-    fprintf(stdout, "    %-23s %s\n", "--clear-cache", "clear local database");
-    fprintf(stdout, "    %-23s %s\n", "--verbose", "display verbose output (when used with --clear-cache or --update)");
-    fprintf(stdout, "    %-23s %s\n", "--list", "list all entries in the local database");
+    fprintf(stdout, "    %-23s %s\n", "-c, --clear-cache", "clear local database");
+    fprintf(stdout, "    %-23s %s\n", "-V, --verbose", "display verbose output (when used with --clear-cache or --update)");
+    fprintf(stdout, "    %-23s %s\n", "-l, --list", "list all entries in the local database");
     fprintf(stdout, "    %-23s %s\n", "--linux", "show command page for Linux");
     fprintf(stdout, "    %-23s %s\n", "--osx", "show command page for OSX");
     fprintf(stdout, "    %-23s %s\n", "--sunos", "show command page for SunOS");

--- a/src/tldr.c
+++ b/src/tldr.c
@@ -238,7 +238,7 @@ void print_usage(char const *arg){
     fprintf(stdout, "    %-23s %s\n", "-u, --update", "update local database");
     fprintf(stdout, "    %-23s %s\n", "-v, --version", "print version and exit");
     fprintf(stdout, "    %-23s %s\n", "-c, --clear-cache", "clear local database");
-    fprintf(stdout, "    %-23s %s\n", "-V, --verbose", "display verbose output (when used with --clear-cache or --update)");
+    fprintf(stdout, "    %-23s %s\n", "-V, --verbose", "display verbose output (when used with -c or -u)");
     fprintf(stdout, "    %-23s %s\n", "-l, --list", "list all entries in the local database");
     /* *INDENT-ON* */
 }


### PR DESCRIPTION
Not a complex change. Explicitly define the flags to avoid any problems. The reason why options like -c work is because GNU getopt supports abbreviated arguments.