### PR TITLE
Improve complete.bash

### DIFF
--- a/autocomplete/complete.bash
+++ b/autocomplete/complete.bash
@@ -6,14 +6,14 @@
 
 # usage: _tldr_get_files [architecture] [semi-completed word to search]
 _tldr_get_files() {
-    find "$HOME"/.tldrc/tldr/pages/"$1" -name "$2"'*.md' -exec basename {} .md \;
+    find "$HOME"/.tldrc/tldr/pages/"$1" -name "$2"'*.md' -exec basename -s .md {} +
 }
 
 _tldr_complete() {
     COMPREPLY=()
     local word="${COMP_WORDS[COMP_CWORD]}"
     local cmpl=""
-    if [[ "$word" == "--"* ]] || [ -z "$word" ]; then
+    if [[ "$word" == "--"* ]]; then
         cmpl=$'--help\n--color\n--platform\n--render\n--update\n--version\n--clear-cache\n--verbose\n--list'
     elif [[ "$word" == "-"* ]]; then
         cmpl=$'-h\n-C\n-p\n-r\n-u\n-v\n-c\n-V\n-l'

--- a/autocomplete/complete.bash
+++ b/autocomplete/complete.bash
@@ -4,38 +4,36 @@
 # Copyright (C) 2016 Arvid Gerstmann
 #
 
+# usage: _tldr_get_files [architecture] [semi-completed word to search]
 _tldr_get_files() {
-	local ret
-	local files="$(find $HOME/.tldrc/tldr/pages/$1 -name '*.md' -exec basename {} .md \;)"
-
-	IFS=$'\n\t'
-	for f in $files; do
-	    echo $f
-	done
+    find "$HOME"/.tldrc/tldr/pages/"$1" -name "$2"'*.md' -exec basename {} .md \;
 }
 
 _tldr_complete() {
     COMPREPLY=()
-	local word="${COMP_WORDS[COMP_CWORD]}"
-	local cmpl=""
+    local word="${COMP_WORDS[COMP_CWORD]}"
+    local cmpl=""
     if [ "$word" = "-" ]; then
-        cmpl=$(echo $'\n-v\n-h\n-u\n-c\n-p\n-r' | sort)
+        cmpl=$'\n-v\n-h\n-u\n-c\n-p\n-r'
     elif [ "$word" = "--" ]; then
-        cmpl=$(echo $'--version\n--help\n--update\n--clear-cache\n--platform\n--render' | sort)
+        cmpl=$'--version\n--help\n--update\n--clear-cache\n--platform\n--render'
     else
         if [ -d "$HOME/.tldrc/tldr/pages" ]; then
-            local platform="$(uname)"
-            cmpl="$(_tldr_get_files common | sort | uniq)"
+            local platform
+            platform="$(uname)"
+            cmpl="$(_tldr_get_files common "$word")"
             if [ "$platform" = "Darwin" ]; then
-                cmpl="${cmpl}$(_tldr_get_files osx | sort | uniq)"
+                cmpl="${cmpl}$(_tldr_get_files osx "$word")"
             elif [ "$platform" = "Linux" ]; then
-                cmpl="${cmpl}$(_tldr_get_files linux | sort | uniq)"
+                cmpl="${cmpl}$(_tldr_get_files linux "$word")"
             elif [ "$platform" = "SunOS" ]; then
-                cmpl="${cmpl}$(_tldr_get_files sunos | sort | uniq)"
+                cmpl="${cmpl}$(_tldr_get_files sunos "$word")"
             fi
         fi
     fi
-    COMPREPLY=( $(compgen -W "$cmpl" -- "$word") )
+    local cmpl_sorted_n_uniq
+    cmpl_sorted_n_uniq=$(printf "%s" "$cmpl" | sort | uniq)
+    COMPREPLY=( $(compgen -W "$cmpl_sorted_n_uniq" -- "$word") )
 }
 
 complete -F _tldr_complete tldr

--- a/autocomplete/complete.bash
+++ b/autocomplete/complete.bash
@@ -13,10 +13,12 @@ _tldr_complete() {
     COMPREPLY=()
     local word="${COMP_WORDS[COMP_CWORD]}"
     local cmpl=""
-    if [ "$word" = "-" ]; then
-        cmpl=$'\n-v\n-h\n-u\n-c\n-p\n-r'
-    elif [ "$word" = "--" ]; then
+    if [[ "$word" == "--"* ]] || [ -z "$word" ]; then
         cmpl=$'--version\n--help\n--update\n--clear-cache\n--platform\n--render'
+    elif [[ "$word" == "-"* ]]; then
+        cmpl=$'\n-v\n-h\n-u\n-c\n-p\n-r'
+    elif [[ "$word" == *"/"* ]]; then # the file command will give an error if passed directly since this will be a directory name - an invalid command
+        cmpl=""
     else
         if [ -d "$HOME/.tldrc/tldr/pages" ]; then
             local platform
@@ -35,5 +37,4 @@ _tldr_complete() {
     cmpl_sorted_n_uniq=$(printf "%s" "$cmpl" | sort | uniq)
     COMPREPLY=( $(compgen -W "$cmpl_sorted_n_uniq" -- "$word") )
 }
-
 complete -F _tldr_complete tldr

--- a/autocomplete/complete.bash
+++ b/autocomplete/complete.bash
@@ -25,11 +25,14 @@ _tldr_complete() {
             platform="$(uname)"
             cmpl="$(_tldr_get_files common "$word")"
             if [ "$platform" = "Darwin" ]; then
-                cmpl="${cmpl}$(_tldr_get_files osx "$word")"
+                cmpl="${cmpl}
+$(_tldr_get_files osx "$word")"
             elif [ "$platform" = "Linux" ]; then
-                cmpl="${cmpl}$(_tldr_get_files linux "$word")"
+                cmpl="${cmpl}
+$(_tldr_get_files linux "$word")"
             elif [ "$platform" = "SunOS" ]; then
-                cmpl="${cmpl}$(_tldr_get_files sunos "$word")"
+                cmpl="${cmpl}
+$(_tldr_get_files sunos "$word")"
             fi
         fi
     fi

--- a/autocomplete/complete.bash
+++ b/autocomplete/complete.bash
@@ -14,9 +14,9 @@ _tldr_complete() {
     local word="${COMP_WORDS[COMP_CWORD]}"
     local cmpl=""
     if [[ "$word" == "--"* ]] || [ -z "$word" ]; then
-        cmpl=$'--version\n--help\n--update\n--clear-cache\n--platform\n--render'
+        cmpl=$'--help\n--color\n--platform\n--render\n--update\n--version\n--clear-cache\n--verbose\n--list'
     elif [[ "$word" == "-"* ]]; then
-        cmpl=$'\n-v\n-h\n-u\n-c\n-p\n-r'
+        cmpl=$'-h\n-C\n-p\n-r\n-u\n-v\n-c\n-V\n-l'
     elif [[ "$word" == *"/"* ]]; then # the file command will give an error if passed directly since this will be a directory name - an invalid command
         cmpl=""
     else


### PR DESCRIPTION
## What does it do?

Improves `complete.bash` by:
- removing the redundant loop in `_tldr_get_files()`, which does nothing but re-`echo`es the same output.
- removing the redundant `| sort | uniq` calls.
- the `_tldr_get_files()` now only returns the matching results, instead of returning thousands of lines each time.
- applies fix similar to #105 for bash.
- earlier version could not actually autocomplete on cases such as `--vers`, which it should autocomplete. This version would autocomplete in that case to `tldr --version`.
- earlier not all command line options were present in this file (such as `--verbose`); this version adds them.

## Why the change?

The autocomplete function almost freezes (on my system) for almost 20 secs (I am using it in bash). This is due to the above reasons. This version reduces that time to almost instantaneous.

## How can this be tested?

Install the autocomplete file just as is described in this repo's `README.md`, and try to use completion (with tab key press) in bash.

## Where to start code review?

I've already mentioned the major changes in the **What does it do?** section.

## Questions?

N/A

### Checklist

- [x] I have checked there aren't any existing PRs open to fix this issue/add this feature.
- [ ] I have compiled the code with `make` and tested the change in an active installation with `sudo make install`.

Notes for (2) : Since this is not a change in the code for the actual `tldr` program, I have not run (2); but rather tested the change with the steps I mentioned in **How can this be tested?** section.