### PR TITLE
[Enhancement] search platform list to find a command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ will be removed after two major releases.
 - Fix updating a local database
 - Prevent freezing of auto-completion in zsh
 - Fix print usage of flags
+- Search a command in all platforms if it is not found in user's platform.
 
 ### Removed
 

--- a/src/tldr.h
+++ b/src/tldr.h
@@ -53,6 +53,8 @@
 #define ANSI_BOLD_ON                            "\x1b[1m"
 #define ANSI_BOLD_OFF                           "\x1b[22m"
 
+#define PLATFORM_CNT 5
+extern const char * const platformlist[PLATFORM_CNT];
 /* local.c */
 long        check_localdate         (void);
 int         update_localdate        (void);


### PR DESCRIPTION
[Enhancement]  Search commands in all platforms if it is not found in current user's platform 

## What does it do?

make tldr-c-client to find a command in all platforms if it is not found in user's platform.

## Why the change?

To enhance tldr-c-client as mentioned in  https://github.com/tldr-pages/tldr-c-client/issues/96

## How can this be tested?

run `tldr <command>` where the command is not found in current user's platform.
After this change, it should be able to find the command description even it is not in user's platform.

## Where to start code review?

Main change: src/parser.c
1. abstract the logic and make the function name more descriptive (i.e. IsPageInPlatformList)
2. add platformList in tldr.h for scalability. Developers only have to update the list in tldr.h, and the list can be used in any *.c files.

## Relevant tickets?

https://github.com/tldr-pages/tldr-c-client/issues/96

## Questions?

<Ask us anything!>

### Checklist

- [X] I have checked there aren't any existing PRs open to fix this issue/add this feature.
- [X] I have compiled the code with `make` and tested the change in an active installation with `sudo make install`.
