### PR TITLE
Fix ZIP_URL_LEN constant

### DIFF
--- a/src/tldr.h
+++ b/src/tldr.h
@@ -18,7 +18,7 @@
 #define BASE_URL_LEN (sizeof(BASE_URL) - 1)
 
 #define ZIP_URL "https://github.com/tldr-pages/tldr/archive/main.zip"
-#define ZIP_URL_LEN (sizeof(ZIP_URL_LEN) - 1)
+#define ZIP_URL_LEN (sizeof(ZIP_URL) - 1)
 
 /* Relative to TLDR_HOME */
 #define TMP_DIR "/tmp"


### PR DESCRIPTION
## What does it do?

Fixes definition of ZIP_URL_LEN constant to be `(sizeof(ZIP_URL) - 1)` instead of `(sizeof(ZIP_URL_LEN) - 1)`.

## Why the change?

The constant ZIP_URL_LEN is meant to hold the length of the string ZIP_URL.

## How can this be tested?

It cannot, because the constant isn't used anywhere.

### Checklist

- [x] I have checked there aren't any existing PRs open to fix this issue/add this feature.
- [x] I have compiled the code with `make` and tested the change in an active installation with `sudo make install`.
